### PR TITLE
Fix for a change in API

### DIFF
--- a/EventMapHpViewer/Models/MapData.cs
+++ b/EventMapHpViewer/Models/MapData.cs
@@ -16,7 +16,6 @@ namespace EventMapHpViewer.Models
         private readonly RemoteSettingsClient client = new RemoteSettingsClient();
         public int Id { get; set; }
         public int IsCleared { get; set; }
-        //public int IsExBoss { get; set; }
         public int DefeatCount { get; set; }
         public int RequiredDefeatCount { get; set; }
         public Eventmap Eventmap { get; set; }

--- a/EventMapHpViewer/Models/MapData.cs
+++ b/EventMapHpViewer/Models/MapData.cs
@@ -16,8 +16,9 @@ namespace EventMapHpViewer.Models
         private readonly RemoteSettingsClient client = new RemoteSettingsClient();
         public int Id { get; set; }
         public int IsCleared { get; set; }
-        public int IsExBoss { get; set; }
+        //public int IsExBoss { get; set; }
         public int DefeatCount { get; set; }
+        public int RequiredDefeatCount { get; set; }
         public Eventmap Eventmap { get; set; }
 
         public MapInfo Master => Maps.MapInfos[this.Id];
@@ -34,7 +35,7 @@ namespace EventMapHpViewer.Models
         {
             get
             {
-                if (this.IsExBoss == 1) return this.Master.RequiredDefeatCount;
+                if (this.RequiredDefeatCount > 0) return this.Master.RequiredDefeatCount;
                 return this.Eventmap != null
                     ? this.Eventmap.MaxMapHp
                     : 1;
@@ -45,7 +46,7 @@ namespace EventMapHpViewer.Models
         {
             get
             {
-                if (this.IsExBoss == 1) return this.Master.RequiredDefeatCount - this.DefeatCount;  //ゲージ有り通常海域
+                if (this.RequiredDefeatCount > 0) return this.Master.RequiredDefeatCount - this.DefeatCount;  //ゲージ有り通常海域
                 return this.Eventmap != null
                     ? this.Eventmap.NowMapHp   // イベント海域
                     : 1;    // ゲージ無し通常海域
@@ -61,7 +62,7 @@ namespace EventMapHpViewer.Models
 
             if (!this.Current.HasValue) return null;    //難易度切り替え直後
 
-            if (this.IsExBoss == 1) return new RemainingCount(this.Current.Value);    //ゲージ有り通常海域
+            if (this.RequiredDefeatCount > 1) return new RemainingCount(this.Current.Value);    //ゲージ有り通常海域
 
             if (this.Eventmap == null) return new RemainingCount(1);    //ゲージ無し通常海域
 

--- a/EventMapHpViewer/Models/MapData.cs
+++ b/EventMapHpViewer/Models/MapData.cs
@@ -61,7 +61,7 @@ namespace EventMapHpViewer.Models
 
             if (!this.Current.HasValue) return null;    //難易度切り替え直後
 
-            if (this.RequiredDefeatCount > 1) return new RemainingCount(this.Current.Value);    //ゲージ有り通常海域
+            if (this.RequiredDefeatCount > 0) return new RemainingCount(this.Current.Value);    //ゲージ有り通常海域
 
             if (this.Eventmap == null) return new RemainingCount(1);    //ゲージ無し通常海域
 

--- a/EventMapHpViewer/Models/MapInfoProxy.cs
+++ b/EventMapHpViewer/Models/MapInfoProxy.cs
@@ -99,7 +99,7 @@ namespace EventMapHpViewer.Models
                 {
                     IsCleared = x.api_cleared,
                     DefeatCount = x.api_defeat_count,
-                    IsExBoss = x.api_exboss_flag,
+                    RequiredDefeatCount = x.api_required_defeat_count,
                     Id = x.api_id,
                     Eventmap = x.api_eventmap != null
                         ? new Eventmap

--- a/EventMapHpViewer/Models/Raw/member_mapinfo.cs
+++ b/EventMapHpViewer/Models/Raw/member_mapinfo.cs
@@ -14,8 +14,5 @@
         //public int api_gauge_type { get; set; }
         //public int api_gauge_num { get; set; }
         public Api_Eventmap api_eventmap { get; set; }
-
-        //Removed from the API
-        //public int api_exboss_flag { get; set; }
     }
 }

--- a/EventMapHpViewer/Models/Raw/member_mapinfo.cs
+++ b/EventMapHpViewer/Models/Raw/member_mapinfo.cs
@@ -9,8 +9,13 @@
     {
         public int api_id { get; set; }
         public int api_cleared { get; set; }
-        public int api_exboss_flag { get; set; }
         public int api_defeat_count { get; set; }
+        public int api_required_defeat_count { get; set; }
+        //public int api_gauge_type { get; set; }
+        //public int api_gauge_num { get; set; }
         public Api_Eventmap api_eventmap { get; set; }
+
+        //Removed from the API
+        //public int api_exboss_flag { get; set; }
     }
 }


### PR DESCRIPTION
I don't know how the previous API looked like, but apparently `api_exboss_flag` had been removed from `member_mapinfo`. It caused `EventMapHpViewer.Models.MapData.Max` and `EventMapHpViewer.Models.MapData.Current` properties to return `1` every time. This fix utilises `api_required_defeat_count` instead to determine whether the map is an extra operation map or not. 

Related: #3 

* api_exboss_flag removed (Commented out for now, shall I remove it completely?)
* 'api_exboss_flag == 0' comparisons replaced with 'api_required_defeat_count > 0'