### PR TITLE
Add default TP value of equipment 'M4A1 DD'

### DIFF
--- a/EventMapHpViewer/Models/Settings/AutoCalcTpSettings.cs
+++ b/EventMapHpViewer/Models/Settings/AutoCalcTpSettings.cs
@@ -147,6 +147,7 @@ namespace EventMapHpViewer.Models.Settings
                 new TpSetting(193, 193, "特大発動艇", 8),
                 new TpSetting(166, 166, "大発動艇(八九式中戦車＆陸戦隊)", 8),
                 new TpSetting(230, 230, "特大発動艇＋戦車第11連隊", 8),
+                new TpSetting(355, 355, "M4A1 DD", 8),
                 new TpSetting(167, 167, "特二式内火艇", 2),
                 new TpSetting(145, 145, "戦闘糧食", 1),
                 new TpSetting(150, 150, "秋刀魚の缶詰", 1),


### PR DESCRIPTION
It has been proved that 'M4A1 DD' could be regarded as something familiar with '特大発動艇+戦車第11連隊', which brings 8 TP.