### PR TITLE
normalize the counting of map 7-2, which has ever cleared even

### DIFF
--- a/EventMapHpViewer/Models/MapInfoProxy.cs
+++ b/EventMapHpViewer/Models/MapInfoProxy.cs
@@ -97,7 +97,7 @@ namespace EventMapHpViewer.Models
             return maps
                 .Select(x => new MapData
                 {
-                    IsCleared = x.api_cleared,
+                    IsCleared = x.api_defeat_count.HasValue ? 0 : x.api_cleared,
                     DefeatCount = x.api_defeat_count ?? 0,
                     RequiredDefeatCount = x.api_required_defeat_count ?? 0,
                     Id = x.api_id,


### PR DESCRIPTION
Until now, map 7-2 refresh monthly due to 2-phases feature; however, when 7-2 has been cleared once, flag IsCleared becomes true, for some reason (upcoming maps, e.g. 7-3, I guess), which makes a bug that the counting only appears at the first time.
And this branch could fix it.