### PR TITLE
Add null check to avoid exception during initializing

### DIFF
--- a/EventMapHpViewer/ViewModels/Settings/SettingsViewModel.cs
+++ b/EventMapHpViewer/ViewModels/Settings/SettingsViewModel.cs
@@ -34,7 +34,7 @@ namespace EventMapHpViewer.ViewModels.Settings
         private void Initialize()
         {
             this.BossSettings.MapItemsSource
-                = Models.Maps.MapInfos
+                = Models.Maps.MapInfos?
                 .Where(x => 20 < x.Value.MapAreaId)
                 .Select(x => x.Value)
                 .Select(x => new KeyValuePair<int, string>(x.Id, $"{x.MapAreaId}-{x.IdInEachMapArea} : {x.Name} - {x.OperationName}"))


### PR DESCRIPTION
For lacking null check during initialization, the plugin would throw an exception, sometimes, which may cause the layout of KCV not responding until one complete sortie back to homeport.
And this branch might solve the problem.