### PR TITLE
Fix null exception about initial

### DIFF
--- a/EventMapHpViewer/ViewModels/Settings/SettingsViewModel.cs
+++ b/EventMapHpViewer/ViewModels/Settings/SettingsViewModel.cs
@@ -34,11 +34,11 @@ namespace EventMapHpViewer.ViewModels.Settings
         private void Initialize()
         {
             this.BossSettings.MapItemsSource
-                = Models.Maps.MapInfos
+                = KanColleClient.Current.Master.MapInfos
                 .Where(x => 20 < x.Value.MapAreaId)
                 .Select(x => x.Value)
                 .Select(x => new KeyValuePair<int, string>(x.Id, $"{x.MapAreaId}-{x.IdInEachMapArea} : {x.Name} - {x.OperationName}"))
-                .ToArray();
+                .ToArray();     
             this.BossSettings.IsEnabled = true;
 
             this.TpSettings.Settings.UpdateFromMaster();

--- a/EventMapHpViewer/ViewModels/Settings/SettingsViewModel.cs
+++ b/EventMapHpViewer/ViewModels/Settings/SettingsViewModel.cs
@@ -38,7 +38,7 @@ namespace EventMapHpViewer.ViewModels.Settings
                 .Where(x => 20 < x.Value.MapAreaId)
                 .Select(x => x.Value)
                 .Select(x => new KeyValuePair<int, string>(x.Id, $"{x.MapAreaId}-{x.IdInEachMapArea} : {x.Name} - {x.OperationName}"))
-                .ToArray();     
+                .ToArray();
             this.BossSettings.IsEnabled = true;
 
             this.TpSettings.Settings.UpdateFromMaster();


### PR DESCRIPTION
For the function of `BossSettings.MapItemsSource`, it seems to be with same output from either `Models.Maps.MapInfos` or `KanColleClient.Current.Master.MapInfos` sources.
While the initial trigger is related to `KanColleClient.Current.IsStarted`, and at same time `Models.Maps.MapInfos` hasn't been initialized already, it couldn't be a bad way to change origin data from `Models.Maps` to `KanColleClient.Current`.