### PR TITLE
Add default TP value of new landingcraft equipments

### DIFF
--- a/EventMapHpViewer/Models/Settings/AutoCalcTpSettings.cs
+++ b/EventMapHpViewer/Models/Settings/AutoCalcTpSettings.cs
@@ -148,10 +148,12 @@ namespace EventMapHpViewer.Models.Settings
                 new TpSetting(166, 166, "大発動艇(八九式中戦車＆陸戦隊)", 8),
                 new TpSetting(230, 230, "特大発動艇＋戦車第11連隊", 8),
                 new TpSetting(355, 355, "M4A1 DD", 8),
+                new TpSetting(409, 409, "武装大発", 8),
+                new TpSetting(408, 408, "装甲艇(AB艇)", 8),
                 new TpSetting(167, 167, "特二式内火艇", 2),
                 new TpSetting(145, 145, "戦闘糧食", 1),
                 new TpSetting(150, 150, "秋刀魚の缶詰", 1),
-                new TpSetting(241, 241, "戦闘糧食(特別なおにぎり)", 1),
+                new TpSetting(241, 241, "戦闘糧食(特別なおにぎり)", 1), 
             };
 
             var shipTp = new[]

--- a/EventMapHpViewer/Models/Settings/AutoCalcTpSettings.cs
+++ b/EventMapHpViewer/Models/Settings/AutoCalcTpSettings.cs
@@ -153,7 +153,7 @@ namespace EventMapHpViewer.Models.Settings
                 new TpSetting(167, 167, "特二式内火艇", 2),
                 new TpSetting(145, 145, "戦闘糧食", 1),
                 new TpSetting(150, 150, "秋刀魚の缶詰", 1),
-                new TpSetting(241, 241, "戦闘糧食(特別なおにぎり)", 1), 
+                new TpSetting(241, 241, "戦闘糧食(特別なおにぎり)", 1),
             };
 
             var shipTp = new[]


### PR DESCRIPTION
It has been proved that '武装大発'& '装甲艇(AB艇)' could be regarded as other landing-crafts , which brings 8 TP.